### PR TITLE
supoprt for pipewire audio player

### DIFF
--- a/tomatoshell
+++ b/tomatoshell
@@ -52,10 +52,12 @@ total_hours_used() {
     awk -F ',' '{sum+=$2 * $3;} END{printf "%d", int(sum / 3600);}' $LOG
     printf "h 🍅🤓\n"
 }
- 
+
 
 # TODO: add option for xdg-open
 find_sound_system() {
+    # added support for pipewire audio player, tested on pop-os (debian)
+    # since, its packed with the OS.
     if command -v mpv &> /dev/null
     then
         AUDIO_PLAYER=mpv
@@ -63,11 +65,15 @@ find_sound_system() {
     elif command -v paplay &> /dev/null
     then
         AUDIO_PLAYER=paplay
+    # set AUDIO_PLAYER as pw-play 
+    elif command -v pw-play &> /dev/null
+    then
+        AUDIO_PLAYER=pw-play
 
     elif command -v aplay &> /dev/null
     then
         AUDIO_PLAYER=aplay
-   
+
     else
         AUDIO_PLAYER=0
     fi


### PR DESCRIPTION
 I added support for pipewire audio player, tested on pop-os (debian), since, its already packed with the OS. When i configured, it was unable to play the sound since POP os ship with pipewire and trying to install other raises a conflict, i could have remove and installed pulse-audio, but since i am lazy i tweaked the code and tested and it was all ok.

here pw-play ships with pipewire and i can play media with it.