### PR TITLE
Make output from report (-r) show hours, minutes and seconds

### DIFF
--- a/tomatoshell
+++ b/tomatoshell
@@ -50,9 +50,9 @@ write_to_log() {
 
 
 total_hours_used() {
-    printf "$YELLOW Total hours spent focused: $FIN"
-    awk -F ',' '{sum+=$2 * $3;} END{printf "%d", int(sum / 3600);}' $LOG
-    printf "h 🍅🤓\n"
+    printf "$YELLOW Total time spent focused: $FIN"
+    awk -F ',' '{sum+=$2 * $3;} END{hours=int(sum/3600); minutes=int((sum%3600)/60); seconds=int(sum%60); printf "%dh:%dm:%ds", hours, minutes, seconds;}' $LOG
+    printf " 🍅🤓\n"
 }
 
 


### PR DESCRIPTION
Noticed the current version only outputs report as full hours completed. That along with [this logging issue](https://github.com/LytixDev/tomatoshell/issues/25) confused me a bit so I made it more detailed. Maybe the seconds is overkill. Anyway, it's yours if you want to use it.