### PR TITLE
Fixed timer issues which arose when premature exit happens

### DIFF
--- a/tomatoshell
+++ b/tomatoshell
@@ -42,10 +42,15 @@ YELLOW="\033[0;33m"
 CYAN="\033[0;34m"
 FIN="\033[0m"
 
+COMPLETED_SESSIONS=0
+ACTUAL_TIME=0
+
 
 write_to_log() {
     date_f=$(date +"%Y-%m-%d")
-    echo "$date_f,$SESSIONS,$TIME" >> "$LOG"
+    # Convert ACTUAL_TIME back to minutes for logging
+    actual_minutes=$((ACTUAL_TIME / 60))
+    echo "$date_f,$COMPLETED_SESSIONS,$actual_minutes" >> "$LOG"
 }
 
 
@@ -153,11 +158,17 @@ countdown() {
 
     # date in seconds when countdown will end
     start=$(($(date +%s) + $1)); 
+    initial_time=$1  # Store initial time value
 
     display_countdown $start
     clear
 
-    [ $session_number -ne -1 ] && notify-send -t 10000 -u "normal" "Session number $session_number finished"
+    # If this was a work session (not a break), increment completed sessions and time
+    if [ $session_number -ne -1 ]; then
+        COMPLETED_SESSIONS=$((COMPLETED_SESSIONS + 1))
+        ACTUAL_TIME=$((ACTUAL_TIME + initial_time))
+        notify-send -t 10000 -u "normal" "Session number $session_number finished"
+    fi
     
     # message when session is finished
     if $FIGLET


### PR DESCRIPTION
Typically, the log file contains the `$SESSION `which inherits the values which gets passed as the CLI _args_ rather than the elapsed session value during the progress of the timer. This merge fixes it and uses the elapsed session by keeping a count of it.

GPT summary of the commit:
This pull request includes changes to the `tomatoshell` script to improve logging and session tracking. The key updates involve adding new variables to track completed sessions and actual time spent, and modifying the logging and countdown functions accordingly.

Improvements to session tracking and logging:

* [`tomatoshell`](diffhunk://#diff-a0459adcf5b778c75543a18bcf20b0904a955a8dec44a84062187a41245097b7R45-R53): Added `COMPLETED_SESSIONS` and `ACTUAL_TIME` variables to track the number of completed sessions and the total actual time spent.
* [`tomatoshell`](diffhunk://#diff-a0459adcf5b778c75543a18bcf20b0904a955a8dec44a84062187a41245097b7R45-R53): Updated the `write_to_log` function to log `COMPLETED_SESSIONS` and convert `ACTUAL_TIME` back to minutes for accurate logging.
* [`tomatoshell`](diffhunk://#diff-a0459adcf5b778c75543a18bcf20b0904a955a8dec44a84062187a41245097b7R161-R171): Modified the `countdown` function to increment `COMPLETED_SESSIONS` and `ACTUAL_TIME` after each work session and store the initial time value for accurate tracking. 